### PR TITLE
Implement neon landing page design

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,73 +21,142 @@
     <!-- Full-screen background simulation canvas -->
     <canvas id="landing-bg" aria-hidden="true"></canvas>
 
-    <!-- Centred content card -->
-    <div class="landing-content">
+    <nav class="landing-nav" aria-label="Landing navigation">
+      <div class="nav-logo">GAME <span>of</span> LIFE</div>
+      <div class="nav-links">
+        <a href="#rules">Rules</a>
+        <a href="#howto">How to Play</a>
+        <a href="#patterns">Patterns</a>
+      </div>
+    </nav>
 
-      <h1 class="landing-title">Conway's<br>Game&nbsp;of&nbsp;Life</h1>
-
-      <p class="landing-subtitle">A zero-player game that evolves from an initial state.</p>
-
-      <!-- Rule cards -->
-      <div class="rule-cards">
-
-        <div class="rule-card">
-          <canvas id="card-canvas-1" class="rule-canvas" aria-hidden="true"></canvas>
-          <h2 class="rule-title">Underpopulation</h2>
-          <p class="rule-desc">A live cell with fewer than&nbsp;2 live neighbours&nbsp;dies.</p>
+    <section class="landing-hero" aria-labelledby="landing-title">
+      <div class="landing-grid-lines" aria-hidden="true"></div>
+      <div class="landing-content">
+        <p class="hero-tag">Conway's Cellular Automaton · 1970</p>
+        <h1 id="landing-title" class="landing-title glitch-animate">
+          GAME<br><span>OF</span> <em>LIFE</em>
+        </h1>
+        <p class="landing-subtitle">
+          A zero-player game where life emerges from simple rules.
+          Watch patterns evolve, collide, and multiply in real time.
+        </p>
+        <div class="hero-cta">
+          <button id="landing-play" class="landing-btn landing-start" aria-label="Start the game">
+            <span>Play Now</span>
+          </button>
+          <a class="landing-link" href="#rules">Learn the Rules</a>
         </div>
-
-        <div class="rule-card">
-          <canvas id="card-canvas-2" class="rule-canvas" aria-hidden="true"></canvas>
-          <h2 class="rule-title">Survival</h2>
-          <p class="rule-desc">A live cell with 2 or&nbsp;3 live neighbours&nbsp;lives on.</p>
+        <div class="hero-stats" aria-label="Live simulation statistics">
+          <div class="stat"><span class="stat-num" id="cell-count">0</span><span class="stat-label">Live Cells</span></div>
+          <div class="stat"><span class="stat-num" id="gen-count">0</span><span class="stat-label">Generation</span></div>
+          <div class="stat"><span class="stat-num">∞</span><span class="stat-label">Possibilities</span></div>
         </div>
+      </div>
+    </section>
 
-        <div class="rule-card">
-          <canvas id="card-canvas-3" class="rule-canvas" aria-hidden="true"></canvas>
-          <h2 class="rule-title">Overpopulation</h2>
-          <p class="rule-desc">A live cell with more than&nbsp;3 live neighbours&nbsp;dies.</p>
+    <section id="rules" class="landing-section" aria-labelledby="rules-title">
+      <div class="section-inner">
+        <p class="section-tag">The Four Laws</p>
+        <h2 id="rules-title" class="section-title">Rules of Existence</h2>
+        <div class="rule-cards">
+          <article class="rule-card">
+            <div class="rule-canvas-wrap"><canvas id="card-canvas-1" class="rule-canvas" aria-hidden="true"></canvas></div>
+            <span class="rule-number">01</span>
+            <h3 class="rule-title">Underpopulation</h3>
+            <p class="rule-desc">A live cell with fewer than 2 live neighbours dies.</p>
+          </article>
+
+          <article class="rule-card">
+            <div class="rule-canvas-wrap"><canvas id="card-canvas-2" class="rule-canvas" aria-hidden="true"></canvas></div>
+            <span class="rule-number">02</span>
+            <h3 class="rule-title">Survival</h3>
+            <p class="rule-desc">A live cell with 2 or 3 live neighbours lives on.</p>
+          </article>
+
+          <article class="rule-card">
+            <div class="rule-canvas-wrap"><canvas id="card-canvas-3" class="rule-canvas" aria-hidden="true"></canvas></div>
+            <span class="rule-number">03</span>
+            <h3 class="rule-title">Overpopulation</h3>
+            <p class="rule-desc">A live cell with more than 3 live neighbours dies.</p>
+          </article>
+
+          <article class="rule-card">
+            <span class="rule-number">04</span>
+            <h3 class="rule-title">Reproduction</h3>
+            <p class="rule-desc">A dead cell with exactly 3 live neighbours becomes alive.</p>
+          </article>
         </div>
+      </div>
+    </section>
 
-      </div><!-- /.rule-cards -->
+    <section id="howto" class="landing-section" aria-labelledby="howto-title">
+      <div class="section-inner">
+        <p class="section-tag">Getting Started</p>
+        <h2 id="howto-title" class="section-title">How to Play</h2>
+        <div class="steps-row">
+          <article class="step">
+            <span class="step-num">STEP 01</span>
+            <h3 class="step-title">Draw Your Pattern</h3>
+            <p class="step-desc">Tap or drag across the grid to toggle cells alive or dead and create your seed.</p>
+          </article>
+          <article class="step">
+            <span class="step-num">STEP 02</span>
+            <h3 class="step-title">Start the Simulation</h3>
+            <p class="step-desc">Press play and watch each generation unfold from the four simple rules.</p>
+          </article>
+          <article class="step">
+            <span class="step-num">STEP 03</span>
+            <h3 class="step-title">Observe &amp; Iterate</h3>
+            <p class="step-desc">Pause, step forward, adjust speed, and load classic patterns from the menu.</p>
+          </article>
+        </div>
+      </div>
+    </section>
 
-      <!-- Pattern types showcase -->
-      <div class="pattern-showcase">
-        <p class="showcase-label">Load classic patterns from the in-game Patterns menu</p>
+    <section id="patterns" class="landing-section pattern-showcase" aria-labelledby="patterns-title">
+      <div class="section-inner">
+        <p class="section-tag">Known Patterns</p>
+        <h2 id="patterns-title" class="section-title">Classic Seeds Included</h2>
         <div class="pattern-type-cards">
-
-          <div class="pattern-type-card">
+          <article class="pattern-type-card">
             <canvas id="demo-canvas-1" class="demo-canvas" aria-hidden="true"></canvas>
             <strong class="pattern-type-name">Still Life</strong>
-            <p class="pattern-type-desc">Stable forever — never changes.</p>
-          </div>
-
-          <div class="pattern-type-card">
+            <p class="pattern-type-desc">Stable forever.</p>
+          </article>
+          <article class="pattern-type-card">
             <canvas id="demo-canvas-2" class="demo-canvas" aria-hidden="true"></canvas>
             <strong class="pattern-type-name">Oscillator</strong>
-            <p class="pattern-type-desc">Repeats on a fixed cycle.</p>
-          </div>
-
-          <div class="pattern-type-card">
+            <p class="pattern-type-desc">Repeats on a cycle.</p>
+          </article>
+          <article class="pattern-type-card">
             <canvas id="demo-canvas-3" class="demo-canvas" aria-hidden="true"></canvas>
             <strong class="pattern-type-name">Spaceship</strong>
-            <p class="pattern-type-desc">Travels across the grid forever.</p>
-          </div>
-
-          <div class="pattern-type-card pattern-type-card--wide">
+            <p class="pattern-type-desc">Travels the grid.</p>
+          </article>
+          <article class="pattern-type-card">
             <canvas id="demo-canvas-4" class="demo-canvas" aria-hidden="true"></canvas>
             <strong class="pattern-type-name">Gun</strong>
-            <p class="pattern-type-desc">Fires an endless stream of spaceships.</p>
-          </div>
-
+            <p class="pattern-type-desc">Fires spaceships.</p>
+          </article>
         </div>
-      </div><!-- /.pattern-showcase -->
+      </div>
+    </section>
 
-      <button id="landing-play" class="landing-btn" aria-label="Start the game">
-        Play
-      </button>
+    <section class="landing-cta" aria-labelledby="cta-title">
+      <div class="landing-grid-lines" aria-hidden="true"></div>
+      <div class="cta-content">
+        <p class="hero-tag">Ready to Begin?</p>
+        <h2 id="cta-title" class="cta-title">BEGIN<br><span>YOUR UNIVERSE</span></h2>
+        <p class="cta-sub">Every great pattern starts with a single living cell.</p>
+        <button class="landing-btn landing-start" type="button">Launch Game</button>
+      </div>
+    </section>
 
-    </div><!-- /.landing-content -->
+    <footer class="landing-footer">
+      <span>GAME OF LIFE · CONWAY'S CELLULAR AUTOMATON</span>
+      <span>2026 · berkayturanci</span>
+    </footer>
 
   </div><!-- /#landing -->
 

--- a/src/landing.js
+++ b/src/landing.js
@@ -79,25 +79,34 @@ class BackgroundSim {
     ctx.clearRect(0, 0, w, h);
     ctx.fillStyle = accent;
 
+    let live = 0;
     for (let row = 0; row < game.rows; row++) {
       for (let col = 0; col < game.cols; col++) {
         if (game.grid[row * game.cols + col]) {
+          live++;
           ctx.fillRect(col * cellW + 0.5, row * cellH + 0.5, cellW - 0.5, cellH - 0.5);
         }
       }
     }
+
+    const cellCount = document.getElementById('cell-count');
+    if (cellCount) cellCount.textContent = live.toLocaleString();
   }
 
   _loop() {
     // Step every ~100ms (≈10fps) to keep CPU light
     const STEP_INTERVAL = 100;
     let last = 0;
+    let generation = 0;
     const tick = (ts) => {
       if (this.rafId === null) return; // stopped
       this.rafId = requestAnimationFrame(tick);
       if (ts - last >= STEP_INTERVAL) {
         this.game.step();
+        generation++;
         this._draw();
+        const genCount = document.getElementById('gen-count');
+        if (genCount) genCount.textContent = generation.toLocaleString();
         last = ts;
       }
     };
@@ -366,7 +375,7 @@ class PatternDemo {
 export function initLanding(onPlay) {
   const landing   = document.getElementById('landing');
   const bgCanvas  = document.getElementById('landing-bg');
-  const playBtn   = document.getElementById('landing-play');
+  const playBtns  = document.querySelectorAll('.landing-start');
 
   // Background simulation
   const bgSim = new BackgroundSim(bgCanvas);
@@ -390,9 +399,9 @@ export function initLanding(onPlay) {
   patternDemos.forEach(d => d.start());
 
   // Play button → transition
-  playBtn.addEventListener('click', () => {
+  const startGame = () => {
     // Prevent double-clicks
-    playBtn.disabled = true;
+    playBtns.forEach(btn => { btn.disabled = true; });
 
     // Fade out landing
     landing.classList.add('landing--fade-out');
@@ -424,5 +433,7 @@ export function initLanding(onPlay) {
     // Safety: if transitionend never fires (e.g. prefers-reduced-motion),
     // fall back after the expected duration + a small buffer.
     setTimeout(finish, transDuration + 100);
-  });
+  };
+
+  playBtns.forEach(btn => btn.addEventListener('click', startGame));
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -551,3 +551,457 @@ button.active {
     max-width: 260px;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Design handoff: full neon landing page
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+#landing {
+  display: block;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+}
+
+#landing::before {
+  position: fixed;
+  z-index: 6;
+}
+
+#landing::after {
+  display: none;
+}
+
+#landing-bg {
+  position: fixed;
+  opacity: 0.38;
+}
+
+.landing-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 64px;
+  padding: 16px clamp(20px, 5vw, 48px);
+  border-bottom: 1px solid oklch(0.2 0.06 195 / 0.55);
+  background: oklch(0.04 0.02 195 / 0.78);
+  backdrop-filter: blur(14px);
+}
+
+.nav-logo {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-shadow: 0 0 20px var(--accent);
+}
+
+.nav-logo span {
+  color: var(--muted);
+  font-weight: 300;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 4vw, 36px);
+}
+
+.nav-links a,
+.landing-link {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.nav-links a:hover,
+.landing-link:hover {
+  color: var(--cyan);
+}
+
+.landing-hero,
+.landing-cta {
+  position: relative;
+  z-index: 3;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  padding: 96px 20px 72px;
+  overflow: hidden;
+}
+
+.landing-grid-lines {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse at center, black 28%, transparent 76%);
+}
+
+.landing-content,
+.cta-content {
+  position: relative;
+  z-index: 4;
+  width: min(920px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+  padding: 0;
+  text-align: center;
+}
+
+.hero-tag,
+.section-tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-shadow: 0 0 12px var(--accent);
+}
+
+.hero-tag {
+  border: 1px solid oklch(0.45 0.18 145 / 0.45);
+  padding: 7px 16px;
+  background: oklch(0.04 0.02 195 / 0.45);
+  animation: landingFadeUp 0.8s ease both;
+}
+
+.landing-title {
+  font-size: clamp(3.25rem, 10vw, 7rem);
+  line-height: 0.9;
+  color: var(--text);
+  text-shadow:
+    0 0 60px oklch(0.75 0.22 145 / 0.3),
+    0 0 120px oklch(0.75 0.22 145 / 0.1);
+  animation: fadeSlideUp 0.9s 0.15s ease both, glitch 6s 1s infinite;
+}
+
+.landing-title span {
+  color: var(--accent);
+  font-style: normal;
+  text-shadow: 0 0 40px var(--accent);
+}
+
+.landing-title em {
+  color: var(--cyan);
+  font-style: normal;
+  text-shadow: 0 0 40px var(--cyan);
+}
+
+.landing-subtitle {
+  max-width: 560px;
+  margin-top: 0;
+  text-align: left;
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  background: oklch(0.04 0.02 195 / 0.46);
+  animation: fadeSlideUp 0.9s 0.3s ease both;
+}
+
+.hero-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  animation: fadeSlideUp 0.9s 0.45s ease both;
+}
+
+.landing-btn {
+  gap: 10px;
+  min-height: 54px;
+  padding: 16px 38px;
+  font-size: 13px;
+}
+
+.landing-link {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 3px;
+}
+
+.hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: clamp(22px, 6vw, 48px);
+  flex-wrap: wrap;
+  animation: fadeSlideUp 0.9s 0.6s ease both;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 92px;
+}
+
+.stat-num {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--accent);
+  text-shadow: 0 0 16px var(--accent);
+}
+
+.stat-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.landing-section {
+  position: relative;
+  z-index: 4;
+  padding: clamp(72px, 10vw, 120px) clamp(20px, 5vw, 48px);
+  border-top: 1px solid var(--border);
+  background: oklch(0.06 0.025 195 / 0.92);
+}
+
+.landing-section:nth-of-type(odd) {
+  background: oklch(0.035 0.018 195 / 0.92);
+}
+
+.section-inner {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+}
+
+.section-tag {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--cyan);
+  text-shadow: 0 0 12px var(--cyan);
+  margin-bottom: 16px;
+}
+
+.section-tag::before {
+  content: '';
+  width: 32px;
+  height: 1px;
+  background: var(--cyan);
+  box-shadow: 0 0 8px var(--cyan);
+}
+
+.section-title {
+  font-family: var(--mono);
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.05;
+  color: var(--text);
+  margin-bottom: 48px;
+}
+
+.rule-cards,
+.steps-row,
+.pattern-type-cards {
+  display: grid;
+  gap: 2px;
+}
+
+.rule-cards {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  animation: none;
+}
+
+.steps-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.pattern-type-cards {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.rule-card,
+.step,
+.pattern-type-card {
+  align-items: flex-start;
+  text-align: left;
+  min-width: 0;
+  max-width: none;
+  min-height: 220px;
+  padding: 32px;
+  background: oklch(0.07 0.03 195 / 0.76);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(10px);
+}
+
+.rule-card {
+  display: flex;
+}
+
+.rule-canvas-wrap {
+  align-self: flex-end;
+  opacity: 0.72;
+}
+
+.rule-number {
+  font-family: var(--mono);
+  font-size: 54px;
+  font-weight: 800;
+  line-height: 1;
+  color: oklch(0.19 0.06 195);
+}
+
+.rule-title,
+.pattern-type-name,
+.step-num {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-shadow: 0 0 10px var(--accent);
+}
+
+.rule-desc,
+.step-desc,
+.pattern-type-desc,
+.cta-sub {
+  max-width: 32ch;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: oklch(0.7 0.04 195);
+  line-height: 1.65;
+}
+
+.step {
+  position: relative;
+}
+
+.step-title {
+  margin: 24px 0 12px;
+  font-family: var(--sans);
+  font-size: 1.35rem;
+  color: var(--text);
+}
+
+.pattern-type-card {
+  align-items: center;
+  text-align: center;
+  min-height: 190px;
+}
+
+.demo-canvas,
+.rule-canvas {
+  image-rendering: pixelated;
+}
+
+.landing-cta {
+  min-height: 72svh;
+  border-top: 1px solid var(--border);
+  background: oklch(0.04 0.02 195 / 0.94);
+}
+
+.cta-title {
+  font-family: var(--mono);
+  font-size: clamp(2.5rem, 7vw, 5.5rem);
+  font-weight: 800;
+  line-height: 0.95;
+}
+
+.cta-title span {
+  color: var(--accent);
+  text-shadow: 0 0 40px var(--accent);
+}
+
+.landing-footer {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 28px clamp(20px, 5vw, 48px);
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes glitch {
+  0%, 90%, 100% {
+    transform: none;
+    text-shadow:
+      0 0 60px oklch(0.75 0.22 145 / 0.3),
+      0 0 120px oklch(0.75 0.22 145 / 0.1);
+  }
+  92% {
+    transform: translateX(-3px) skewX(-1deg);
+    text-shadow: -3px 0 var(--cyan), 3px 0 oklch(0.7 0.2 345 / 0.5);
+  }
+  94% {
+    transform: translateX(3px) skewX(1deg);
+    text-shadow: 3px 0 var(--accent), -3px 0 oklch(0.7 0.2 345 / 0.5);
+  }
+}
+
+@media (max-width: 900px) {
+  .rule-cards,
+  .steps-row,
+  .pattern-type-cards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-links {
+    display: none;
+  }
+
+  .landing-hero {
+    padding-top: 72px;
+  }
+
+  .rule-cards,
+  .steps-row,
+  .pattern-type-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .rule-card,
+  .step,
+  .pattern-type-card {
+    min-height: 0;
+    padding: 26px;
+  }
+
+  .landing-footer {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-title,
+  .hero-tag,
+  .landing-subtitle,
+  .hero-cta,
+  .hero-stats,
+  .landing-btn {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

- Implement the Claude Design handoff as the main landing experience inside index.html.
- Preserve the existing Play transition into the Game of Life app.
- Add live simulation stats, neon hero/rules/how-to/patterns/CTA sections, and responsive styling.

## Validation

- [x] npm test - 2 files, 75 tests passed
- [x] git diff --check
- [ ] Local browser smoke test at http://localhost:8080
- [ ] iOS Safari/touch smoke test, if canvas controls or responsive layout changed

## Notes

Design handoff read from Anthropic tar.gz export. The repo does not have a separate landing-page.html entry point, so the relevant design was mapped into the existing index.html landing screen and supporting styles/landing script.