### PR TITLE
Align landing page with design handoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <div class="nav-links">
         <a href="#rules">Rules</a>
         <a href="#howto">How to Play</a>
-        <a href="#patterns">Patterns</a>
+        <button class="nav-play landing-start" type="button">Play Now</button>
       </div>
     </nav>
 
@@ -52,6 +52,10 @@
           <div class="stat"><span class="stat-num" id="gen-count">0</span><span class="stat-label">Generation</span></div>
           <div class="stat"><span class="stat-num">∞</span><span class="stat-label">Possibilities</span></div>
         </div>
+      </div>
+      <div class="hero-scroll" aria-hidden="true">
+        <span class="scroll-text">Scroll</span>
+        <div class="scroll-line"></div>
       </div>
     </section>
 
@@ -82,6 +86,7 @@
           </article>
 
           <article class="rule-card">
+            <div class="rule-canvas-wrap"><canvas id="card-canvas-4" class="rule-canvas" aria-hidden="true"></canvas></div>
             <span class="rule-number">04</span>
             <h3 class="rule-title">Reproduction</h3>
             <p class="rule-desc">A dead cell with exactly 3 live neighbours becomes alive.</p>
@@ -111,39 +116,22 @@
             <p class="step-desc">Pause, step forward, adjust speed, and load classic patterns from the menu.</p>
           </article>
         </div>
-      </div>
-    </section>
-
-    <section id="patterns" class="landing-section pattern-showcase" aria-labelledby="patterns-title">
-      <div class="section-inner">
-        <p class="section-tag">Known Patterns</p>
-        <h2 id="patterns-title" class="section-title">Classic Seeds Included</h2>
-        <div class="pattern-type-cards">
-          <article class="pattern-type-card">
-            <canvas id="demo-canvas-1" class="demo-canvas" aria-hidden="true"></canvas>
-            <strong class="pattern-type-name">Still Life</strong>
-            <p class="pattern-type-desc">Stable forever.</p>
-          </article>
-          <article class="pattern-type-card">
-            <canvas id="demo-canvas-2" class="demo-canvas" aria-hidden="true"></canvas>
-            <strong class="pattern-type-name">Oscillator</strong>
-            <p class="pattern-type-desc">Repeats on a cycle.</p>
-          </article>
-          <article class="pattern-type-card">
-            <canvas id="demo-canvas-3" class="demo-canvas" aria-hidden="true"></canvas>
-            <strong class="pattern-type-name">Spaceship</strong>
-            <p class="pattern-type-desc">Travels the grid.</p>
-          </article>
-          <article class="pattern-type-card">
-            <canvas id="demo-canvas-4" class="demo-canvas" aria-hidden="true"></canvas>
-            <strong class="pattern-type-name">Gun</strong>
-            <p class="pattern-type-desc">Fires spaceships.</p>
-          </article>
+        <div class="known-patterns">
+          <div>
+            <p class="known-label">Known Patterns</p>
+            <p class="known-copy">Start with a Glider, Blinker, or Gosper Glider Gun — classic patterns included.</p>
+          </div>
+          <div class="known-items">
+            <span><i></i>Glider</span>
+            <span><i></i>Blinker</span>
+            <span><i></i>Glider Gun</span>
+          </div>
         </div>
       </div>
     </section>
 
     <section class="landing-cta" aria-labelledby="cta-title">
+      <canvas id="cta-canvas" aria-hidden="true"></canvas>
       <div class="landing-grid-lines" aria-hidden="true"></div>
       <div class="cta-content">
         <p class="hero-tag">Ready to Begin?</p>

--- a/src/landing.js
+++ b/src/landing.js
@@ -305,6 +305,15 @@ class OverpopDemo extends CardDemo {
   buildFrames() { return buildOverpopFrames(); }
 }
 
+class ReproductionDemo extends CardDemo {
+  buildFrames() {
+    const before = new Uint8Array(25);
+    [6, 8, 16].forEach(i => { before[i] = 1; });
+    const after = stepCard5x5(before);
+    return [before, after, after, before];
+  }
+}
+
 // ─── Pattern type demos ───────────────────────────────────────────────────────
 
 const DEMO_STILL = [[0,0],[1,0],[0,1],[1,1]]; // Block (still life)
@@ -370,6 +379,95 @@ class PatternDemo {
   stop() { cancelAnimationFrame(this.rafId); this.rafId = null; }
 }
 
+// ─── CTA background: Gosper Glider Gun ───────────────────────────────────────
+
+const GOSPER_GUN = [
+  [0,4],[0,5],[1,4],[1,5],
+  [10,4],[10,5],[10,6],[11,3],[11,7],[12,2],[12,8],[13,2],[13,8],
+  [14,5],[15,3],[15,7],[16,4],[16,5],[16,6],[17,5],
+  [20,2],[20,3],[20,4],[21,2],[21,3],[21,4],[22,1],[22,5],
+  [24,0],[24,1],[24,5],[24,6],
+  [34,2],[34,3],[35,2],[35,3],
+];
+
+class CtaGunSim {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas?.getContext('2d');
+    this.game = new GameOfLife(70, 40);
+    this.rafId = null;
+    this.last = 0;
+    this.generation = 0;
+    this._resizeHandler = () => this._resize();
+  }
+
+  start() {
+    if (!this.canvas || !this.ctx) return;
+    this._seed();
+    this._resize();
+    window.addEventListener('resize', this._resizeHandler);
+    this.rafId = requestAnimationFrame(ts => this._loop(ts));
+  }
+
+  stop() {
+    cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+
+  _seed() {
+    this.game.clear();
+    const offC = 2;
+    const offR = 8;
+    for (const [c, r] of GOSPER_GUN) this.game.set(c + offC, r + offR, 1);
+    this.generation = 0;
+  }
+
+  _resize() {
+    const dpr = window.devicePixelRatio || 1;
+    const w = this.canvas.offsetWidth;
+    const h = this.canvas.offsetHeight;
+    this.canvas.width = w * dpr;
+    this.canvas.height = h * dpr;
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  _draw() {
+    const { ctx, canvas, game } = this;
+    const w = canvas.offsetWidth;
+    const h = canvas.offsetHeight;
+    const cell = Math.min(w / game.cols, h / game.rows) * 0.85;
+    const offX = (w - game.cols * cell) / 2;
+    const offY = (h - game.rows * cell) / 2;
+    const accent = css('--accent') || '#4ade80';
+    const cyan = css('--cyan') || '#22d3ee';
+
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = accent;
+    ctx.shadowColor = cyan;
+    ctx.shadowBlur = 8;
+    for (let row = 0; row < game.rows; row++) {
+      for (let col = 0; col < game.cols; col++) {
+        if (game.grid[row * game.cols + col]) {
+          ctx.fillRect(offX + col * cell + 1, offY + row * cell + 1, cell - 1.5, cell - 1.5);
+        }
+      }
+    }
+    ctx.shadowBlur = 0;
+  }
+
+  _loop(ts) {
+    if (this.rafId === null) return;
+    this.rafId = requestAnimationFrame(nextTs => this._loop(nextTs));
+    if (ts - this.last < 100) return;
+    this.last = ts;
+    this.game.step();
+    this.generation++;
+    if (this.generation > 300) this._seed();
+    this._draw();
+  }
+}
+
 // ─── Landing screen orchestrator ─────────────────────────────────────────────
 
 export function initLanding(onPlay) {
@@ -386,17 +484,12 @@ export function initLanding(onPlay) {
     new UnderpopDemo(document.getElementById('card-canvas-1')),
     new SurvivalDemo(document.getElementById('card-canvas-2')),
     new OverpopDemo(document.getElementById('card-canvas-3')),
+    new ReproductionDemo(document.getElementById('card-canvas-4')),
   ];
   demos.forEach(d => d.start());
 
-  // Pattern type demos
-  const patternDemos = [
-    new PatternDemo(document.getElementById('demo-canvas-1'), DEMO_STILL, 10, 10,  8),
-    new PatternDemo(document.getElementById('demo-canvas-2'), DEMO_OSCIL, 10, 10,  8,  5),
-    new PatternDemo(document.getElementById('demo-canvas-3'), DEMO_SHIP,  16, 16,  5),
-    new PatternDemo(document.getElementById('demo-canvas-4'), DEMO_GUN,   50, 20,  4,  8),
-  ];
-  patternDemos.forEach(d => d.start());
+  const ctaSim = new CtaGunSim(document.getElementById('cta-canvas'));
+  ctaSim.start();
 
   // Play button → transition
   const startGame = () => {
@@ -420,7 +513,7 @@ export function initLanding(onPlay) {
       // Stop background animation to save CPU
       bgSim.stop();
       demos.forEach(d => d.stop());
-      patternDemos.forEach(d => d.stop());
+      ctaSim.stop();
 
       // Hide landing so game canvas can resize correctly
       landing.style.display = 'none';

--- a/styles/main.css
+++ b/styles/main.css
@@ -578,8 +578,10 @@ button.active {
 }
 
 .landing-nav {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  right: 0;
   z-index: 10;
   display: flex;
   align-items: center;
@@ -614,18 +616,27 @@ button.active {
 }
 
 .nav-links a,
-.landing-link {
+.landing-link,
+.nav-play {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   transition: color 0.2s, border-color 0.2s;
 }
 
 .nav-links a:hover,
-.landing-link:hover {
+.landing-link:hover,
+.nav-play:hover {
   color: var(--cyan);
 }
 
@@ -633,11 +644,40 @@ button.active {
 .landing-cta {
   position: relative;
   z-index: 3;
-  min-height: 100svh;
+  min-height: 700px;
+  height: 100svh;
   display: grid;
   place-items: center;
   padding: 96px 20px 72px;
   overflow: hidden;
+}
+
+.hero-scroll {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  z-index: 4;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  animation: fadeIn 1.2s 1s ease both;
+}
+
+.scroll-text {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.scroll-line {
+  width: 1px;
+  height: 48px;
+  background: linear-gradient(to bottom, var(--accent), transparent);
+  animation: scrollPulse 2s infinite;
 }
 
 .landing-grid-lines {
@@ -816,7 +856,7 @@ button.active {
 }
 
 .rule-cards {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   animation: none;
 }
 
@@ -853,7 +893,7 @@ button.active {
 
 .rule-number {
   font-family: var(--mono);
-  font-size: 54px;
+  font-size: 72px;
   font-weight: 800;
   line-height: 1;
   color: oklch(0.19 0.06 195);
@@ -892,6 +932,60 @@ button.active {
   color: var(--text);
 }
 
+.known-patterns {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-top: 48px;
+  padding: 32px;
+  border: 1px solid var(--border);
+  background: oklch(0.07 0.03 195 / 0.55);
+}
+
+.known-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--cyan);
+  margin-bottom: 8px;
+}
+
+.known-copy {
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.known-items {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.known-items span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.known-items i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  animation: pulseDot 1.5s infinite;
+}
+
 .pattern-type-card {
   align-items: center;
   text-align: center;
@@ -907,6 +1001,16 @@ button.active {
   min-height: 72svh;
   border-top: 1px solid var(--border);
   background: oklch(0.04 0.02 195 / 0.94);
+}
+
+#cta-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 .cta-title {
@@ -942,6 +1046,16 @@ button.active {
   to { opacity: 1; transform: translateY(0); }
 }
 
+@keyframes scrollPulse {
+  0%, 100% { opacity: 0.3; transform: scaleY(1); }
+  50% { opacity: 1; transform: scaleY(1.2); }
+}
+
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.7); }
+}
+
 @keyframes glitch {
   0%, 90%, 100% {
     transform: none;
@@ -961,8 +1075,7 @@ button.active {
 
 @media (max-width: 900px) {
   .rule-cards,
-  .steps-row,
-  .pattern-type-cards {
+  .steps-row {
     grid-template-columns: 1fr 1fr;
   }
 }
@@ -977,8 +1090,7 @@ button.active {
   }
 
   .rule-cards,
-  .steps-row,
-  .pattern-type-cards {
+  .steps-row {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

- Compare the live landing page against the latest Anthropic design handoff.
- Align rules, hero, navigation, known-patterns band, and CTA structure more closely with landing-page.html.
- Add the fourth reproduction rule mini-canvas and CTA Gosper gun background simulation.

## Validation

- [x] npm test - 2 files, 75 tests passed
- [x] git diff --check

## Notes

Live HTML matched main, but main differed from the new design handoff in structure and section details. This PR tightens those differences while preserving the existing in-page Play transition into the game.