### PR TITLE
Add neighbour-aware cell colors and renderer tests

### DIFF
--- a/src/landing.js
+++ b/src/landing.js
@@ -8,6 +8,7 @@
  */
 
 import { GameOfLife } from './game.js';
+import { liveCellColor } from './renderer.js';
 
 // ─── CSS custom property helpers ─────────────────────────────────────────────
 
@@ -74,20 +75,27 @@ class BackgroundSim {
     const h = canvas.height / dpr;
     const cellW = w / game.cols;
     const cellH = h / game.rows;
-    const accent = css('--accent') || '#4ade80';
+    const liveColors = {
+      sparse: css('--cell-sparse') || 'rgb(0,255,160)',
+      stable: css('--cell-stable') || 'rgb(0,237,207)',
+      crowded: css('--cell-crowded') || 'rgb(0,220,255)',
+    };
 
     ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = accent;
 
     let live = 0;
     for (let row = 0; row < game.rows; row++) {
       for (let col = 0; col < game.cols; col++) {
         if (game.grid[row * game.cols + col]) {
           live++;
+          ctx.fillStyle = liveCellColor(game.countNeighbors(col, row), liveColors);
+          ctx.shadowColor = ctx.fillStyle;
+          ctx.shadowBlur = 8;
           ctx.fillRect(col * cellW + 0.5, row * cellH + 0.5, cellW - 0.5, cellH - 0.5);
         }
       }
     }
+    ctx.shadowBlur = 0;
 
     const cellCount = document.getElementById('cell-count');
     if (cellCount) cellCount.textContent = live.toLocaleString();
@@ -161,7 +169,7 @@ class CardDemo {
 
   _draw(grid) {
     const { ctx, dpr } = this;
-    const accent = css('--accent') || '#4ade80';
+    const accent = css('--cell-sparse') || css('--accent') || '#4ade80';
     const bg     = css('--bg')     || '#0f172a';
     const border = css('--border') || '#334155';
     const logical = CARD_COLS * CARD_CELL;
@@ -358,7 +366,7 @@ class PatternDemo {
     const { cols, rows } = game;
     ctx.fillStyle = css('--dead') || '#0f172a';
     ctx.fillRect(0, 0, cols * cellPx, rows * cellPx);
-    ctx.fillStyle = css('--accent') || '#4ade80';
+    ctx.fillStyle = css('--cell-sparse') || css('--accent') || '#4ade80';
     for (let r = 0; r < rows; r++)
       for (let c = 0; c < cols; c++)
         if (game.grid[r * cols + c])
@@ -439,16 +447,19 @@ class CtaGunSim {
     const cell = Math.min(w / game.cols, h / game.rows) * 0.85;
     const offX = (w - game.cols * cell) / 2;
     const offY = (h - game.rows * cell) / 2;
-    const accent = css('--accent') || '#4ade80';
-    const cyan = css('--cyan') || '#22d3ee';
+    const liveColors = {
+      sparse: css('--cell-sparse') || 'rgb(0,255,160)',
+      stable: css('--cell-stable') || 'rgb(0,237,207)',
+      crowded: css('--cell-crowded') || 'rgb(0,220,255)',
+    };
 
     ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = accent;
-    ctx.shadowColor = cyan;
-    ctx.shadowBlur = 8;
     for (let row = 0; row < game.rows; row++) {
       for (let col = 0; col < game.cols; col++) {
         if (game.grid[row * game.cols + col]) {
+          ctx.fillStyle = liveCellColor(game.countNeighbors(col, row), liveColors);
+          ctx.shadowColor = ctx.fillStyle;
+          ctx.shadowBlur = 8;
           ctx.fillRect(offX + col * cell + 1, offY + row * cell + 1, cell - 1.5, cell - 1.5);
         }
       }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,3 +1,19 @@
+const DEFAULT_LIVE_COLORS = {
+  sparse: 'rgb(0,255,160)',
+  stable: 'rgb(0,237,207)',
+  crowded: 'rgb(0,220,255)',
+};
+
+export function liveCellColor(neighborCount, colors = DEFAULT_LIVE_COLORS) {
+  if (neighborCount >= 3) return colors.crowded;
+  if (neighborCount === 2) return colors.stable;
+  return colors.sparse;
+}
+
+function cssVar(name, fallback) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
 export class Renderer {
   constructor(canvas) {
     this.canvas = canvas;
@@ -43,16 +59,21 @@ export class Renderer {
     const { ctx, cellW, cellH, logicalW, logicalH, showGrid, cols, rows } = this;
     const gap = cellW > 3 ? 0.5 : 0;
 
-    ctx.fillStyle = getComputedStyle(document.documentElement)
-      .getPropertyValue('--dead').trim() || '#0f172a';
+    ctx.fillStyle = cssVar('--dead', '#0f172a');
     ctx.fillRect(0, 0, logicalW, logicalH);
 
-    ctx.fillStyle = getComputedStyle(document.documentElement)
-      .getPropertyValue('--accent').trim() || '#4ade80';
+    const liveColors = {
+      sparse: cssVar('--cell-sparse', DEFAULT_LIVE_COLORS.sparse),
+      stable: cssVar('--cell-stable', DEFAULT_LIVE_COLORS.stable),
+      crowded: cssVar('--cell-crowded', DEFAULT_LIVE_COLORS.crowded),
+    };
 
     for (let row = 0; row < game.rows; row++) {
       for (let col = 0; col < game.cols; col++) {
         if (game.grid[row * game.cols + col]) {
+          ctx.fillStyle = liveCellColor(game.countNeighbors(col, row), liveColors);
+          ctx.shadowColor = ctx.fillStyle;
+          ctx.shadowBlur = cellW >= 8 ? 8 : 0;
           ctx.fillRect(
             col * cellW + gap,
             row * cellH + gap,
@@ -62,10 +83,10 @@ export class Renderer {
         }
       }
     }
+    ctx.shadowBlur = 0;
 
     if (showGrid && cellW > 5) {
-      ctx.strokeStyle = getComputedStyle(document.documentElement)
-        .getPropertyValue('--grid').trim() || '#1e293b';
+      ctx.strokeStyle = cssVar('--grid', '#1e293b');
       ctx.lineWidth = 0.5;
       ctx.beginPath();
       for (let c = 0; c <= cols; c++) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -9,6 +9,9 @@
   --muted:   oklch(0.55 0.04 195);
   --accent:  oklch(0.75 0.22 145);   /* neon green */
   --cyan:    oklch(0.75 0.18 195);   /* neon cyan  */
+  --cell-sparse:  rgb(0, 255, 160);
+  --cell-stable:  rgb(0, 237, 207);
+  --cell-crowded: rgb(0, 220, 255);
   --dead:    #050a0e;
   --grid:    oklch(0.18 0.05 195);
   --btn-h:   44px;

--- a/tests/renderer.test.js
+++ b/tests/renderer.test.js
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GameOfLife } from '../src/game.js';
+import { Renderer, liveCellColor } from '../src/renderer.js';
+
+function makeCtx() {
+  const calls = [];
+  const ctx = {
+    _fillStyle: '',
+    _strokeStyle: '',
+    shadowColor: '',
+    shadowBlur: 0,
+    lineWidth: 0,
+    setTransform: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn((x, y, w, h) => {
+      calls.push({
+        fillStyle: ctx._fillStyle,
+        shadowColor: ctx.shadowColor,
+        shadowBlur: ctx.shadowBlur,
+        x,
+        y,
+        w,
+        h,
+      });
+    }),
+    set fillStyle(value) { this._fillStyle = value; },
+    get fillStyle() { return this._fillStyle; },
+    set strokeStyle(value) { this._strokeStyle = value; },
+    get strokeStyle() { return this._strokeStyle; },
+  };
+  return { ctx, calls };
+}
+
+function cssMap(values) {
+  return name => ({
+    getPropertyValue: prop => values[prop] ?? '',
+  }).getPropertyValue(name);
+}
+
+describe('liveCellColor()', () => {
+  it('uses sparse green for cells with fewer than 2 neighbours', () => {
+    expect(liveCellColor(0)).toBe('rgb(0,255,160)');
+    expect(liveCellColor(1)).toBe('rgb(0,255,160)');
+  });
+
+  it('uses stable teal for cells with exactly 2 neighbours', () => {
+    expect(liveCellColor(2)).toBe('rgb(0,237,207)');
+  });
+
+  it('uses crowded cyan for cells with 3 or more neighbours', () => {
+    expect(liveCellColor(3)).toBe('rgb(0,220,255)');
+    expect(liveCellColor(8)).toBe('rgb(0,220,255)');
+  });
+
+  it('accepts CSS-resolved color overrides', () => {
+    const colors = { sparse: 'green', stable: 'teal', crowded: 'cyan' };
+    expect(liveCellColor(1, colors)).toBe('green');
+    expect(liveCellColor(2, colors)).toBe('teal');
+    expect(liveCellColor(3, colors)).toBe('cyan');
+  });
+});
+
+describe('Renderer', () => {
+  let ctx;
+  let calls;
+  let canvas;
+
+  beforeEach(() => {
+    ({ ctx, calls } = makeCtx());
+    canvas = {
+      width: 0,
+      height: 0,
+      style: {},
+      getContext: vi.fn(() => ctx),
+    };
+
+    globalThis.window = { devicePixelRatio: 2 };
+    globalThis.document = { documentElement: {} };
+    globalThis.getComputedStyle = vi.fn(() => ({
+      getPropertyValue: cssMap({
+        '--dead': '#050a0e',
+        '--cell-sparse': 'green',
+        '--cell-stable': 'teal',
+        '--cell-crowded': 'cyan',
+        '--grid': '#123456',
+      }),
+    }));
+  });
+
+  it('resizes the physical canvas for devicePixelRatio while keeping logical CSS size', () => {
+    const renderer = new Renderer(canvas);
+    renderer.resize(300, 150, 30, 15);
+
+    expect(canvas.width).toBe(600);
+    expect(canvas.height).toBe(300);
+    expect(canvas.style.width).toBe('300px');
+    expect(canvas.style.height).toBe('150px');
+    expect(ctx.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+  });
+
+  it('maps canvas coordinates to grid cells', () => {
+    const renderer = new Renderer(canvas);
+    renderer.resize(300, 150, 30, 15);
+
+    expect(renderer.canvasToCell(29, 19)).toEqual({ col: 2, row: 1 });
+  });
+
+  it('draws live cells with prototype-style neighbour-count colours', () => {
+    const renderer = new Renderer(canvas);
+    renderer.resize(50, 30, 5, 3);
+
+    const game = new GameOfLife(5, 3);
+    game.set(1, 1, 1);
+    game.set(2, 1, 1);
+    game.set(3, 1, 1);
+    game.countNeighbors = vi.fn((col) => ({ 1: 1, 2: 2, 3: 3 })[col] ?? 0);
+
+    renderer.draw(game);
+
+    const liveCellCalls = calls.slice(1, 4);
+    expect(liveCellCalls.map(call => call.fillStyle)).toEqual(['green', 'teal', 'cyan']);
+    expect(liveCellCalls.map(call => call.shadowColor)).toEqual(['green', 'teal', 'cyan']);
+    expect(liveCellCalls.every(call => call.shadowBlur === 8)).toBe(true);
+  });
+
+  it('resets glow before drawing grid lines', () => {
+    const renderer = new Renderer(canvas);
+    renderer.resize(50, 30, 5, 3);
+
+    const game = new GameOfLife(5, 3);
+    game.set(2, 1, 1);
+    renderer.draw(game);
+
+    expect(ctx.stroke).toHaveBeenCalledOnce();
+    expect(ctx.shadowBlur).toBe(0);
+    expect(ctx.strokeStyle).toBe('#123456');
+  });
+});


### PR DESCRIPTION
## Summary

- Apply the prototype-style live-cell color rule to the in-game renderer: sparse cells are green, stable cells are teal, crowded cells are cyan.
- Reuse the same color helper for landing background/CTA simulations so the home page and game agree visually.
- Add renderer unit tests covering DPR resize, coordinate mapping, glow reset, and neighbour-aware colors.

## Validation

- [x] npm test - 3 files, 83 tests passed
- [x] git diff --check

## Notes

This is a rendering-only change; Game of Life rules and grid state are unchanged.