### PR TITLE
fix: add .cfignore to exclude node_modules from Cloudflare Pages deploy

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,14 @@
+# Exclude files/directories from Cloudflare Pages deployment
+# Keep: index.html, brand-assets.html, site.webmanifest, styles/, src/, assets/
+
+node_modules/
+agents/
+tests/
+.github/
+.claude/
+package.json
+package-lock.json
+CLAUDE.md
+README.md
+AGENTS.md
+*.md


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `.cfignore` at the repo root so Cloudflare Pages/Wrangler skips large and dev-only paths during deployment.
- Fixes the `[ERROR] Asset too large` failure caused by `node_modules/workerd/bin/workerd` (118 MiB) being included when `directory: .` is set in the workflow.

## What is excluded

| Path | Reason |
|---|---|
| `node_modules/` | Contains large binaries (workerd 118 MiB) — root cause of the error |
| `agents/` | Dev tooling, not served to users |
| `tests/` | Test files, not served to users |
| `.github/` | CI config, not served to users |
| `.claude/` | Editor config, not served to users |
| `package.json`, `package-lock.json` | Node metadata, not served to users |
| `CLAUDE.md`, `README.md`, `AGENTS.md`, `*.md` | Docs, not served to users |

## What is kept (served)

`index.html`, `brand-assets.html`, `site.webmanifest`, `styles/`, `src/`, `assets/`

## Safety verification

- Branch cut from `origin/main` at commit `f064226` (latest as of this fix)
- `git diff --cached --stat` before commit showed: **1 file changed, 14 insertions(+)** — no deletions, no existing files touched
- Only `.cfignore` was added

https://claude.ai/code/session_018J4N4wYfyGZgmCevc3qDy1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018J4N4wYfyGZgmCevc3qDy1)_