### PR TITLE
fix: switch Cloudflare deploy to Wrangler for Workers project

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy to Cloudflare
 
 on:
   push:
@@ -15,11 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: game-of-life
-          directory: .
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      # Copy only deployable static files — keeps node_modules out entirely
+      - name: Prepare static files
+        run: |
+          mkdir -p dist
+          cp index.html brand-assets.html site.webmanifest dist/
+          cp -r src styles dist/
+          cp -r assets dist/
+
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler@latest deploy --config wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "game-of-life"
+compatibility_date = "2025-01-01"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
## Root cause

The Cloudflare project `game-of-life` is a **Workers** project, not a Pages project. `cloudflare/pages-action@v1` only works with Pages projects → "Project not found" 404 error.

Additionally, Cloudflare's build system runs `npm install` automatically (because `package.json` exists), which creates `node_modules/workerd/bin/workerd` (118 MiB) on disk — exceeding the 25 MiB asset limit.

## Fix

### `wrangler.toml` (new)
Declares the Workers project name and points the assets directory at `./dist`.

### `.github/workflows/cloudflare-pages.yml` (updated)
- Replaces `cloudflare/pages-action@v1` with `npx wrangler@latest deploy`
- Before deploying, copies **only** the static files into `dist/`:
  `index.html`, `brand-assets.html`, `site.webmanifest`, `src/`, `styles/`, `assets/`
- `node_modules` is never created or touched — `dist/` is built from the git checkout directly

## Note on the old Cloudflare GitHub integration
The Cloudflare dashboard has its own build pipeline connected to this repo (the "Workers Builds: game-of-life" check). Once this PR is merged and the GitHub Actions workflow deploys successfully, you can disable the old integration in:
**Cloudflare dashboard → game-of-life → Settings → Build & Deployments → disconnect GitHub** — to avoid duplicate builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_018J4N4wYfyGZgmCevc3qDy1)_