### PR TITLE
fix: pin Node.js 22 in Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       # Copy only deployable static files — keeps node_modules out entirely
       - name: Prepare static files
         run: |


### PR DESCRIPTION
Wrangler 4.87.0 (latest) requires Node.js ≥22.0.0. GitHub Actions default runner ships v20.20.2 → deploy fails immediately.

**Fix:** Add `actions/setup-node@v4` with `node-version: '22'` before the Wrangler deploy step. One-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018J4N4wYfyGZgmCevc3qDy1)_